### PR TITLE
Stop redundant per-frame texture/table churn in OnUpdate

### DIFF
--- a/GoggleMaps.lua
+++ b/GoggleMaps.lua
@@ -208,6 +208,8 @@ function GoggleMaps:Init()
   self.Minimap:Init(contentFrame)
   self.Map:InitZones()
   self.Map:InitInstances()
+  self.Map:UpdateZoneTextures()
+  self.Map:UpdateInstanceTextures()
 
   GoggleMaps.compat.pfQuest:Init(self.frame.Content)
   GoggleMaps.compat.atlas:Init(self.frame.Content)
@@ -254,12 +256,7 @@ function GoggleMaps:handleUpdate()
     self.wasDragging = true
   end
   self.Map:handleUpdate()
-  self.Overlay:handleUpdate()
   self.POI:handleUpdate()
-  self.Minimap:handleUpdate()
-  if self.compat.pfQuest.initialised then
-    self.compat.pfQuest:handleUpdate()
-  end
   self.Player:handleUpdate(self.Map.mapId == self.Map.realMapId)
   self:UpdateLocationText()
   self:UpdateCurrentMapInfo()

--- a/compat/pfQuest.lua
+++ b/compat/pfQuest.lua
@@ -47,7 +47,7 @@ function GoggleMaps.compat.pfQuest:UpdateNodes(newPins)
   self.initialised = true
 end
 
-function GoggleMaps.compat.pfQuest:handleUpdate()
+function GoggleMaps.compat.pfQuest:Refresh()
   local Map = GoggleMaps.Map
   local mapId = Map.mapId
   local scale = Map.scale

--- a/components/Map.lua
+++ b/components/Map.lua
@@ -220,6 +220,10 @@ function GoggleMaps.Map:handleEvent()
       end
     end
     GoggleMaps.Overlay:AddMapIdToZonesToDraw(self.realMapId)
+    self:UpdateZoneTextures()
+    self:UpdateInstanceTextures()
+    GoggleMaps.Overlay:UpdateOverlays()
+    GoggleMaps.Minimap:Refresh()
     GMapsDebug:UpdateItem("zoom", self.scale)
     GMapsDebug:UpdateItem("zoom (ex)", self.previousScale)
     GMapsDebug:UpdateItem("Current zone", GetZoneText())
@@ -365,6 +369,11 @@ function GoggleMaps.Map:MoveMap(xPos, yPos)
   self:MoveContinents()
   self:MoveZones()
   self:MoveInstances()
+  GoggleMaps.Overlay:UpdateOverlays()
+  GoggleMaps.Minimap:Refresh()
+  if GoggleMaps.compat.pfQuest.initialised then
+    GoggleMaps.compat.pfQuest:Refresh()
+  end
 end
 
 function GoggleMaps.Map:MoveContinents()
@@ -466,6 +475,10 @@ function GoggleMaps.Map:handleUpdate()
         Utils.setCurrentMap(self.mapId)
         GoggleMaps.Overlay:AddMapIdToZonesToDraw(self.realMapId)
         GoggleMaps.Overlay:AddMapIdToZonesToDraw(self.mapId)
+        self:UpdateZoneTextures()
+        self:UpdateInstanceTextures()
+        GoggleMaps.Overlay:UpdateOverlays()
+        GoggleMaps.Minimap:Refresh()
       end
       local zoneX, zoneY = Utils.GetZonePosFromWorldPos(self.mapId, worldX, worldY)
       GMapsDebug:UpdateItem("Mouse winpos", { x = winx, y = winy })
@@ -476,10 +489,12 @@ function GoggleMaps.Map:handleUpdate()
       self.mapId = self.realMapId
       Utils.setCurrentMap(self.realMapId)
       GoggleMaps.Overlay:AddMapIdToZonesToDraw(self.realMapId)
+      self:UpdateZoneTextures()
+      self:UpdateInstanceTextures()
+      GoggleMaps.Overlay:UpdateOverlays()
+      GoggleMaps.Minimap:Refresh()
     end
-    self:UpdateZoneTextures()
     self.zoneFrame:SetFrameLevel(GoggleMaps.frameLevels.city)
-    self:UpdateInstanceTextures()
     self.instanceFrame:SetFrameLevel(GoggleMaps.frameLevels.instance)
   end
 

--- a/components/Minimap.lua
+++ b/components/Minimap.lua
@@ -53,7 +53,7 @@ function GoggleMaps.Minimap:HideMiniFrames()
   end
 end
 
-function GoggleMaps.Minimap:handleUpdate()
+function GoggleMaps.Minimap:Refresh()
   local mapId = GoggleMaps.Map.mapId
 
   if not mapId then
@@ -106,9 +106,12 @@ function GoggleMaps.Minimap:handleUpdate()
         frameY = col * baseHeight + y
 
         if Utils.ClipFrame(f, frameX, frameY, baseWidth, baseHeight, clipW, clipH) then
-          f.texture:SetVertexColor(1, 1, 1, 1)
           txname = "Textures\\Minimap\\" .. txname
-          f.texture:SetTexture(txname)
+          if f.lastTexturePath ~= txname then
+            f.texture:SetVertexColor(1, 1, 1, 1)
+            f.texture:SetTexture(txname)
+            f.lastTexturePath = txname
+          end
           f:SetFrameLevel(GoggleMaps.frameLevels.minimap)
         end
       else

--- a/components/Overlay.lua
+++ b/components/Overlay.lua
@@ -11,7 +11,10 @@ GoggleMaps.Overlay = {
   --- The list of zone mapIds to draw. Shouldn't exceed options.maxZonesToDraw
   zonesToDraw = {},
   zonesToClear = {},
-  textureBases = {}
+  textureBases = {},
+  --- Cache of parsed overlayData strings ("offsetX,offsetY,width,height" -> {offsetX, offsetY, width, height}),
+  --- keyed by the raw overlayData string. overlayData is static per zone/texture so this never needs invalidating.
+  parsedOverlayCache = {}
 }
 
 function GoggleMaps.Overlay:InitDB()
@@ -31,10 +34,6 @@ function GoggleMaps.Overlay:Init(parentFrame)
   self.frame = CreateFrame("Frame", "overlayFrame", parentFrame)
   self.frame:SetAllPoints()
   self.frame:SetFrameLevel(GoggleMaps.frameLevels.overlay)
-  self:UpdateOverlays()
-end
-
-function GoggleMaps.Overlay:handleUpdate()
   self:UpdateOverlays()
 end
 
@@ -156,12 +155,18 @@ function GoggleMaps.Overlay:UpdateOverlay(mapId)
   local zoneScale = zone.scale / 10
 
   for textureName, overlayData in pairs(overlays) do
-    local offsetX, offsetY, fullTextureWidth, fullTextureHeight = Utils.splitString(overlayData, ",")
-
-    offsetX = tonumber(offsetX) or 0
-    offsetY = tonumber(offsetY) or 0
-    fullTextureWidth = tonumber(fullTextureWidth) or 0
-    fullTextureHeight = tonumber(fullTextureHeight) or 0
+    local parsed = self.parsedOverlayCache[overlayData]
+    if not parsed then
+      local offsetX, offsetY, fullTextureWidth, fullTextureHeight = Utils.splitString(overlayData, ",")
+      parsed = {
+        tonumber(offsetX) or 0,
+        tonumber(offsetY) or 0,
+        tonumber(fullTextureWidth) or 0,
+        tonumber(fullTextureHeight) or 0
+      }
+      self.parsedOverlayCache[overlayData] = parsed
+    end
+    local offsetX, offsetY, fullTextureWidth, fullTextureHeight = parsed[1], parsed[2], parsed[3], parsed[4]
 
     local numTextureCols = math.ceil(fullTextureWidth / TEXTURE_SIZE)
     local numTextureRows = math.ceil(fullTextureHeight / TEXTURE_SIZE)
@@ -208,7 +213,10 @@ function GoggleMaps.Overlay:UpdateOverlay(mapId)
 
         if self:ClipFrame(f, wx, wy, width, height) then
           local finalTexturePath = self.GetFullTexturePath(zone.overlay, textureName, textureIndex)
-          f.texture:SetTexture(finalTexturePath)
+          if f.lastTexturePath ~= finalTexturePath then
+            f.texture:SetTexture(finalTexturePath)
+            f.lastTexturePath = finalTexturePath
+          end
         end
 
         textureIndex = textureIndex + 1

--- a/components/Player.lua
+++ b/components/Player.lua
@@ -35,6 +35,10 @@ function GoggleMaps.Player:Init(parentFrame)
 
   self.frame = playerFrame
 
+  -- Minimap's children are static once created; caching this avoids rebuilding
+  -- the varargs table on every OnUpdate tick.
+  self.minimapRotateFrame = ({ _G['Minimap']:GetChildren() })[9]
+
   GMapsDebug:AddItem("Player pos", self.position, Utils.positionFormatter)
 end
 
@@ -63,7 +67,7 @@ function GoggleMaps.Player:handleUpdate(isRealMap)
 
 
   local x, y = Utils.GetWorldPos(GoggleMaps.Map.realMapId, playerZoneX, playerZoneY)
-  local direction = ({ _G['Minimap']:GetChildren() })[9]:GetFacing() * -1
+  local direction = self.minimapRotateFrame:GetFacing() * -1
 
   local scale = GoggleMaps.Map.scale
   local clipW = GoggleMaps.Map.size.width

--- a/utils.lua
+++ b/utils.lua
@@ -114,6 +114,10 @@ function Utils.getContinentId(zoneId)
   return math.floor(zoneId / 1000)
 end
 
+--- Cache of computed world info for instance maps, keyed by mapId.
+--- Safe to cache indefinitely: derived purely from static data (Map.Area, Map.InstanceInfo).
+Utils._worldInfoCache = {}
+
 function Utils.GetWorldInfo(mapId)
   if not mapId then
     return nil
@@ -128,20 +132,25 @@ function Utils.GetWorldInfo(mapId)
     return GoggleMaps.Map.MapInfo[continentIndex]
   end
 
+  local cached = Utils._worldInfoCache[mapId]
+  if cached then
+    return cached
+  end
+
   local instanceInfo = GoggleMaps.Map.InstanceInfo[mapId]
   if not instanceInfo then
     return nil
   end
 
-  mapId = instanceInfo.ownerMapId
+  local ownerMapId = instanceInfo.ownerMapId
 
-  if not mapId then
+  if not ownerMapId then
     return nil
   end
 
-  local ownerZoneInfo = GoggleMaps.Map.Area[instanceInfo.ownerMapId]
+  local ownerZoneInfo = GoggleMaps.Map.Area[ownerMapId]
 
-  local posX, posY = Utils.GetWorldPos(instanceInfo.ownerMapId, instanceInfo.entryX, instanceInfo.entryY)
+  local posX, posY = Utils.GetWorldPos(ownerMapId, instanceInfo.entryX, instanceInfo.entryY)
 
   local newWorldInfo = {
     Name = ownerZoneInfo.Name,
@@ -149,6 +158,8 @@ function Utils.GetWorldInfo(mapId)
     X = posX - zoneInfo.x,
     Y = posY - zoneInfo.y
   }
+
+  Utils._worldInfoCache[mapId] = newWorldInfo
 
   return newWorldInfo
 end


### PR DESCRIPTION
## Summary
- `GoggleMapsMain`'s OnUpdate ran the full Overlay/Map/Minimap/pfQuest redraw chain on every rendered frame regardless of whether the map view had changed, reissuing `SetTexture` calls and reallocating tables with unchanged arguments every tick — measured at ~1234 kB/s allocation while standing still with the map open (via pfDebug), vs ~9 kB/s with the map closed.
- Redraw work now runs only at the points that actually mutate view state: `Map:MoveMap()` (the single chokepoint for pan/zoom/resize/player-follow) and the three call sites where `mapId`/`realMapId` change (hotspot hover, revert-to-real, `ZONE_CHANGED_NEW_AREA`), instead of being polled unconditionally every frame.
- `Overlay`'s per-tile overlay-data string parsing is now cached (data is static per zone/texture), and both `Overlay` and `Minimap` skip `SetTexture` when the resolved path hasn't changed.
- `Utils.GetWorldInfo()` caches its result per mapId for instance maps (derived purely from static data).
- Hoisted a per-frame table allocation out of `Player`'s facing-direction lookup.

## Test plan
- [ ] Load in-game, open the map, stand still, verify pfDebug's allocation rate drops close to the closed-map baseline (outdoor/city/instance)
- [ ] Confirm dragging still pans smoothly
- [ ] Confirm scroll-zoom still works and redraws correctly
- [ ] Confirm hovering a hotspot border still peeks the neighboring zone's overlay
- [ ] Confirm walking through a real zone transition updates textures/overlays
- [ ] Confirm player-follow (auto-recenter) still works
- [ ] Confirm pfQuest pins still reposition correctly while panning/zooming (if pfQuest installed)