### PR TITLE
Fix pfQuest icons not repositioning until zoom/pan

### DIFF
--- a/compat/pfQuest.lua
+++ b/compat/pfQuest.lua
@@ -45,6 +45,7 @@ function GoggleMaps.compat.pfQuest:UpdateNodes(newPins)
     end
   end
   self.initialised = true
+  self:Refresh()
 end
 
 function GoggleMaps.compat.pfQuest:Refresh()


### PR DESCRIPTION
## Summary
- pfQuest's `UpdateNodes` hook sets each pin's raw position/size and clears its point, but never called `Refresh()` to actually reposition/rescale it against the current map view
- Since commit 8b014d6 removed the unconditional per-frame `Refresh()` poll, pins now only get repositioned on pan/zoom/move-to-player, so new or changed pfQuest pins stayed misplaced, undersized, or missing until an unrelated pan/zoom happened to trigger a refresh
- Calls `self:Refresh()` at the end of `UpdateNodes` so pins are immediately positioned/scaled whenever pfQuest updates its node set

## Test plan
- [ ] Load pfQuest with GoggleMaps and confirm quest/mob icons appear correctly positioned and sized without needing to zoom in/out
- [ ] Pan and zoom the map to confirm icons still track correctly (no regression of the per-frame churn fix from #30)