### PR TITLE
Stop zoom level from resetting on normal zone changes

### DIFF
--- a/components/Map.lua
+++ b/components/Map.lua
@@ -71,7 +71,8 @@ GoggleMaps.Map = {
   --- @type table<number>
   zoneNameToMapId = {},
 
-  previousZone = 0
+  previousZone = 0,
+  wasInInstance = false
 }
 
 function GoggleMaps.Map:InitDB(force)
@@ -212,12 +213,14 @@ function GoggleMaps.Map:handleEvent()
 
     if self.realMapId ~= self.previousZone then
       self.previousZone = self.realMapId
-      if Utils.IsInstanceMap(self.realMapId) then
+      local isInstance = Utils.IsInstanceMap(self.realMapId)
+      if isInstance and not self.wasInInstance then
         self.previousScale = self.scale + 0.000001 - 0.000001
         self.scale = 300
-      else
+      elseif not isInstance and self.wasInInstance then
         self.scale = self.previousScale + 0.000001 - 0.000001
       end
+      self.wasInInstance = isInstance
     end
     GoggleMaps.Overlay:AddMapIdToZonesToDraw(self.realMapId)
     self:UpdateZoneTextures()


### PR DESCRIPTION
## Summary
- `previousScale` was only ever updated when entering an instance map, but the zone-change handler in `Map:handleEvent` unconditionally overwrote `self.scale` with `previousScale` on every zone transition where the new zone wasn't an instance
- This meant zooming in/out on a normal zone, then walking to any adjacent zone, would silently reset the zoom back to whatever it was before the last instance visit (or the 0.5 default)
- Now scale is only forced to max zoom when actually entering an instance, and only restored when actually leaving one back to a normal zone, tracked via a new `wasInInstance` flag; normal zone-to-zone travel leaves the user's current zoom untouched

## Test plan
- [x] Manually tested: zoom set on a normal zone now persists when walking into an adjacent zone
- [x] Manually tested: entering an instance still forces max zoom, and leaving it restores the pre-instance zoom