### PR TITLE
Respect the user's actual map keybinding instead of hardcoding M

### DIFF
--- a/Bindings.lua
+++ b/Bindings.lua
@@ -2,18 +2,24 @@ BINDING_HEADER_GOGGLEMAPS_HEADER = "GoggleMaps"
 BINDING_NAME_GOGGLEMAPS_TOGGLEMAP = "Toggle Map"
 BINDING_NAME_GOGGLEMAPS_TOGGLE_BLIZZMAP = "Toggle Original Map"
 
-local MAP_KEY = "M"
-local ALT_MAP_KEY = "ALT-" .. MAP_KEY
-
 local function MyAddon_SetBindings()
   -- Try to set up custom bindings
   local ok, err = pcall(function()
+    -- Already bound (from a previous login, or the user rebound it manually) - leave it alone
+    if GetBindingKey("GOGGLEMAPS_TOGGLEMAP") then
+      return
+    end
+
+    -- Take over whatever key the user actually has bound to the default map
+    local mapKey = GetBindingKey("TOGGLEWORLDMAP") or "M"
+    local altMapKey = "ALT-" .. mapKey
+
     -- Unbind Blizzard's map key
-    SetBinding(MAP_KEY)
-    -- Bind M to your addon
-    SetBinding(MAP_KEY, "GOGGLEMAPS_TOGGLEMAP")
-    -- Bind ALT-M to Blizzard’s map
-    SetBinding(ALT_MAP_KEY, "GOGGLEMAPS_TOGGLE_BLIZZMAP")
+    SetBinding(mapKey)
+    -- Bind it to your addon
+    SetBinding(mapKey, "GOGGLEMAPS_TOGGLEMAP")
+    -- Bind ALT-<key> to Blizzard’s map
+    SetBinding(altMapKey, "GOGGLEMAPS_TOGGLE_BLIZZMAP")
     -- Save (2 = per character, 1 = account-wide)
     SaveBindings(2)
   end)
@@ -22,7 +28,7 @@ local function MyAddon_SetBindings()
   if not ok then
     DEFAULT_CHAT_FRAME:AddMessage("|cffff0000[GoggleMaps] Error setting keybindings: " ..
       err .. " - Restoring Blizzard default.|r")
-    SetBinding(MAP_KEY, "TOGGLEWORLDMAP")
+    SetBinding("M", "TOGGLEWORLDMAP")
     SaveBindings(2)
   end
 end


### PR DESCRIPTION
## Summary
- `Bindings.lua` always hijacked the literal `"M"` key on every login, ignoring whatever key the user actually had bound to the default Blizzard map (`TOGGLEWORLDMAP`)
- Now reads `GetBindingKey("TOGGLEWORLDMAP")` to find the real key to take over, falling back to `"M"` only if nothing is bound
- Skips the auto-rebind entirely once `GOGGLEMAPS_TOGGLEMAP` already has a saved binding, so it doesn't fight a manual rebind done via the Key Bindings UI

## Test plan
- [ ] Fresh character/first login: confirm the addon still binds to `M` by default (Blizzard default) and `ALT-M` still opens the original Blizzard map
- [ ] Rebind the default map key away from `M`, `/reloadui`, confirm GoggleMaps now opens on the new key
- [ ] Manually rebind "GoggleMaps: Toggle Map" itself via Key Bindings UI, `/reloadui`, confirm it isn't reverted