### PR TITLE
Add options panel with configurable Escape behavior

### DIFF
--- a/GoggleMaps.lua
+++ b/GoggleMaps.lua
@@ -84,10 +84,12 @@ function GoggleMaps:Start()
   table.insert(UISpecialFrames, self.frame:GetName())
 
   local optionsButton = CreateFrame("Button", ADDON_NAME .. "OptionsButton", self.frame.TitleBar)
-  optionsButton:SetPoint("TopRight", self.frame.TitleBar, "TopRight", -24, 0)
-  optionsButton:SetWidth(18)
-  optionsButton:SetHeight(18)
-  optionsButton:SetNormalTexture("Interface\\Buttons\\UI-OptionsButton")
+  optionsButton:SetPoint("TopRight", self.frame.TitleBar, "TopRight", -22, -1)
+  optionsButton:SetFrameStrata("HIGH")
+  optionsButton:SetFrameLevel(self.frame:GetFrameLevel() + 2)
+  optionsButton:SetWidth(16)
+  optionsButton:SetHeight(16)
+  optionsButton:SetNormalTexture("Interface\\Icons\\INV_Misc_Gear_01")
   optionsButton:SetScript("OnClick", function() GoggleMaps.Options:Toggle() end)
   self.optionsButton = optionsButton
 

--- a/GoggleMaps.lua
+++ b/GoggleMaps.lua
@@ -73,6 +73,7 @@ function GoggleMaps:ResetDB()
   self:InitDB(true)
   self.Map:InitDB(true)
   self.Overlay:InitDB()
+  self.Options:InitDB()
 end
 
 function GoggleMaps:Start()
@@ -81,6 +82,15 @@ function GoggleMaps:Start()
   self.frame:SetFrameStrata("HIGH")
   self.frame:RegisterEvent("PLAYER_LOGIN")
   table.insert(UISpecialFrames, self.frame:GetName())
+
+  local optionsButton = CreateFrame("Button", ADDON_NAME .. "OptionsButton", self.frame.TitleBar)
+  optionsButton:SetPoint("TopRight", self.frame.TitleBar, "TopRight", -24, 0)
+  optionsButton:SetWidth(18)
+  optionsButton:SetHeight(18)
+  optionsButton:SetNormalTexture("Interface\\Buttons\\UI-OptionsButton")
+  optionsButton:SetScript("OnClick", function() GoggleMaps.Options:Toggle() end)
+  self.optionsButton = optionsButton
+
   self.locationLabel = self.frame.TitleBar:CreateFontString("location", "OVERLAY", "GameFontNormalSmall")
   self.positionLabel = self.frame.TitleBar:CreateFontString("position", "OVERLAY", "GameFontNormalSmall")
   self.locationLabel:SetPoint("Left", self.frame.TitleBar, "Left", 4, 0)
@@ -216,6 +226,7 @@ function GoggleMaps:Init()
 
   self.Player:Init(contentFrame)
   self.Hotspots:Init()
+  self.Options:Init()
 
   self.frame:SetScript("OnUpdate", function() self:handleUpdate() end)
   self.frame:SetScript("OnSizeChanged", function() self:handleSizeChanged() end)

--- a/GoggleMaps.toc
+++ b/GoggleMaps.toc
@@ -16,6 +16,7 @@ components\Player.lua
 
 components\UI.lua
 components\UI.Window.lua
+components\Options.lua
 
 components\Map.lua
 data\Map.Area.lua

--- a/components/Options.lua
+++ b/components/Options.lua
@@ -1,0 +1,64 @@
+setfenv(1, GoggleMaps)
+
+local UI = GoggleMaps.UI.Window
+
+GoggleMaps.Options = {
+  ---@type Frame
+  frame = nil,
+  minimizeOnEscape = false
+}
+
+function GoggleMaps.Options:InitDB()
+  if GoggleMapsDB.Options == nil then
+    GoggleMapsDB.Options = {
+      minimizeOnEscape = false
+    }
+  end
+  self.minimizeOnEscape = GoggleMapsDB.Options.minimizeOnEscape
+end
+
+-- Escape normally hides frames listed in UISpecialFrames via the real global HideUIPanel.
+-- Patch the real global (not a sandboxed copy) so FrameXML's ToggleGameMenu sees the override.
+local Blizzard_HideUIPanel = _G.HideUIPanel
+_G.HideUIPanel = function(frame)
+  if frame == GoggleMaps.frame and GoggleMaps.Options.minimizeOnEscape and not GoggleMaps.isMini then
+    GoggleMaps.isMini = true
+    GoggleMapsDB.isMini = true
+    GoggleMaps:RestoreSizeAndPosition()
+    return
+  end
+  Blizzard_HideUIPanel(frame)
+end
+
+function GoggleMaps.Options:Init()
+  self:InitDB()
+
+  local win = UI:CreateWindow("GoggleMapsOptions", 280, 100, UIParent)
+  win:SetTitle("GoggleMaps Options")
+  win:SetPoint("Center", 0, 0)
+  win:SetFrameStrata("DIALOG")
+
+  local checkbox = CreateFrame("CheckButton", "GoggleMapsOptionsEscCheckbox", win.Content, "UICheckButtonTemplate")
+  checkbox:SetPoint("TopLeft", win.Content, "TopLeft", 8, -8)
+  checkbox:SetChecked(self.minimizeOnEscape)
+  checkbox:SetScript("OnClick", function()
+    GoggleMaps.Options.minimizeOnEscape = checkbox:GetChecked() and true or false
+    GoggleMapsDB.Options.minimizeOnEscape = GoggleMaps.Options.minimizeOnEscape
+  end)
+
+  local label = getglobal(checkbox:GetName() .. "Text")
+  label:SetText("Minimize map instead of closing it when pressing Escape")
+  label:SetWidth(220)
+  label:SetJustifyH("LEFT")
+
+  win:Hide()
+  self.frame = win
+end
+
+function GoggleMaps.Options:Toggle()
+  if self.frame:IsShown() then
+    self.frame:Hide()
+  else
+    self.frame:Show()
+  end
+end

--- a/components/Options.lua
+++ b/components/Options.lua
@@ -23,14 +23,14 @@ end
 -- since FrameXML may reference HideUIPanel via a local/upvalue internally.
 -- Patch the real global (not a sandboxed copy) so the keybinding dispatcher sees the override.
 local Blizzard_ToggleGameMenu = _G.ToggleGameMenu
-_G.ToggleGameMenu = function(...)
+_G.ToggleGameMenu = function()
   if GoggleMaps.frame and GoggleMaps.frame:IsShown() and GoggleMaps.Options.minimizeOnEscape and not GoggleMaps.isMini then
     GoggleMaps.isMini = true
     GoggleMapsDB.isMini = true
     GoggleMaps:RestoreSizeAndPosition()
     return
   end
-  Blizzard_ToggleGameMenu(...)
+  Blizzard_ToggleGameMenu()
 end
 
 function GoggleMaps.Options:Init()

--- a/components/Options.lua
+++ b/components/Options.lua
@@ -24,10 +24,13 @@ end
 -- Patch the real global (not a sandboxed copy) so the keybinding dispatcher sees the override.
 local Blizzard_ToggleGameMenu = _G.ToggleGameMenu
 _G.ToggleGameMenu = function()
-  if GoggleMaps.frame and GoggleMaps.frame:IsShown() and GoggleMaps.Options.minimizeOnEscape and not GoggleMaps.isMini then
-    GoggleMaps.isMini = true
-    GoggleMapsDB.isMini = true
-    GoggleMaps:RestoreSizeAndPosition()
+  if GoggleMaps.frame and GoggleMaps.frame:IsShown() and GoggleMaps.Options.minimizeOnEscape then
+    if not GoggleMaps.isMini then
+      GoggleMaps.isMini = true
+      GoggleMapsDB.isMini = true
+      GoggleMaps:RestoreSizeAndPosition()
+    end
+    -- already minimized: swallow Escape instead of closing the map
     return
   end
   Blizzard_ToggleGameMenu()

--- a/components/Options.lua
+++ b/components/Options.lua
@@ -17,17 +17,20 @@ function GoggleMaps.Options:InitDB()
   self.minimizeOnEscape = GoggleMapsDB.Options.minimizeOnEscape
 end
 
--- Escape normally hides frames listed in UISpecialFrames via the real global HideUIPanel.
--- Patch the real global (not a sandboxed copy) so FrameXML's ToggleGameMenu sees the override.
-local Blizzard_HideUIPanel = _G.HideUIPanel
-_G.HideUIPanel = function(frame)
-  if frame == GoggleMaps.frame and GoggleMaps.Options.minimizeOnEscape and not GoggleMaps.isMini then
+-- The ESCAPE keybinding calls the real global ToggleGameMenu() directly (see Bindings.xml),
+-- which is where FrameXML decides to hide whichever UISpecialFrame is on top. Hooking here,
+-- right at the keybinding dispatch point, is more reliable than hooking HideUIPanel itself,
+-- since FrameXML may reference HideUIPanel via a local/upvalue internally.
+-- Patch the real global (not a sandboxed copy) so the keybinding dispatcher sees the override.
+local Blizzard_ToggleGameMenu = _G.ToggleGameMenu
+_G.ToggleGameMenu = function(...)
+  if GoggleMaps.frame and GoggleMaps.frame:IsShown() and GoggleMaps.Options.minimizeOnEscape and not GoggleMaps.isMini then
     GoggleMaps.isMini = true
     GoggleMapsDB.isMini = true
     GoggleMaps:RestoreSizeAndPosition()
     return
   end
-  Blizzard_HideUIPanel(frame)
+  Blizzard_ToggleGameMenu(...)
 end
 
 function GoggleMaps.Options:Init()

--- a/components/Options.lua
+++ b/components/Options.lua
@@ -17,22 +17,42 @@ function GoggleMaps.Options:InitDB()
   self.minimizeOnEscape = GoggleMapsDB.Options.minimizeOnEscape
 end
 
--- The ESCAPE keybinding calls the real global ToggleGameMenu() directly (see Bindings.xml),
--- which is where FrameXML decides to hide whichever UISpecialFrame is on top. Hooking here,
--- right at the keybinding dispatch point, is more reliable than hooking HideUIPanel itself,
--- since FrameXML may reference HideUIPanel via a local/upvalue internally.
+-- While minimizeOnEscape is on, our frame is pulled out of UISpecialFrames (see
+-- UpdateEscapeRegistration below) so the built-in Escape handling skips straight over it -
+-- our own hook is the only thing that reacts to Escape for it in that case. While the
+-- setting is off, the frame stays registered and Escape closes it via the normal
+-- UISpecialFrames/HideUIPanel mechanism, regardless of mini/maxi state.
+local function UpdateEscapeRegistration()
+  local name = GoggleMaps.frame and GoggleMaps.frame:GetName()
+  if not name then
+    return
+  end
+
+  for i = 1, table.getn(UISpecialFrames) do
+    if UISpecialFrames[i] == name then
+      table.remove(UISpecialFrames, i)
+      break
+    end
+  end
+
+  if not GoggleMaps.Options.minimizeOnEscape then
+    table.insert(UISpecialFrames, name)
+  end
+end
+
+-- The ESCAPE keybinding calls the real global ToggleGameMenu() directly (see Bindings.xml).
 -- Patch the real global (not a sandboxed copy) so the keybinding dispatcher sees the override.
 local Blizzard_ToggleGameMenu = _G.ToggleGameMenu
 _G.ToggleGameMenu = function()
-  -- Our frame is in UISpecialFrames, so Escape always targets it first while it's shown at
-  -- all (mini or not) - there's no other way to reach the real game menu via Escape. So a
-  -- second Escape on an already-minimized map has to close it, same as any other UI panel.
   if GoggleMaps.frame and GoggleMaps.frame:IsShown() and GoggleMaps.Options.minimizeOnEscape and not GoggleMaps.isMini then
     GoggleMaps.isMini = true
     GoggleMapsDB.isMini = true
     GoggleMaps:RestoreSizeAndPosition()
     return
   end
+  -- Either the setting is off (frame is in UISpecialFrames, closes as usual), or the
+  -- setting is on and the map is already minimized (frame is untracked, so this just
+  -- falls through to whatever Escape would otherwise do, e.g. the real game menu).
   Blizzard_ToggleGameMenu()
 end
 
@@ -50,6 +70,7 @@ function GoggleMaps.Options:Init()
   checkbox:SetScript("OnClick", function()
     GoggleMaps.Options.minimizeOnEscape = checkbox:GetChecked() and true or false
     GoggleMapsDB.Options.minimizeOnEscape = GoggleMaps.Options.minimizeOnEscape
+    UpdateEscapeRegistration()
   end)
 
   local label = getglobal(checkbox:GetName() .. "Text")
@@ -59,6 +80,8 @@ function GoggleMaps.Options:Init()
 
   win:Hide()
   self.frame = win
+
+  UpdateEscapeRegistration()
 end
 
 function GoggleMaps.Options:Toggle()

--- a/components/Options.lua
+++ b/components/Options.lua
@@ -24,13 +24,13 @@ end
 -- Patch the real global (not a sandboxed copy) so the keybinding dispatcher sees the override.
 local Blizzard_ToggleGameMenu = _G.ToggleGameMenu
 _G.ToggleGameMenu = function()
-  if GoggleMaps.frame and GoggleMaps.frame:IsShown() and GoggleMaps.Options.minimizeOnEscape then
-    if not GoggleMaps.isMini then
-      GoggleMaps.isMini = true
-      GoggleMapsDB.isMini = true
-      GoggleMaps:RestoreSizeAndPosition()
-    end
-    -- already minimized: swallow Escape instead of closing the map
+  -- Our frame is in UISpecialFrames, so Escape always targets it first while it's shown at
+  -- all (mini or not) - there's no other way to reach the real game menu via Escape. So a
+  -- second Escape on an already-minimized map has to close it, same as any other UI panel.
+  if GoggleMaps.frame and GoggleMaps.frame:IsShown() and GoggleMaps.Options.minimizeOnEscape and not GoggleMaps.isMini then
+    GoggleMaps.isMini = true
+    GoggleMapsDB.isMini = true
+    GoggleMaps:RestoreSizeAndPosition()
     return
   end
   Blizzard_ToggleGameMenu()

--- a/environment.lua
+++ b/environment.lua
@@ -57,6 +57,8 @@ function SlashCmdList.GMAPS(msg)
     DEFAULT_CHAT_FRAME:AddMessage("DB reset. Type /reloadui to apply.")
   elseif cmd == "debug" then
     GoggleMaps:ToggleDebug()
+  elseif cmd == "options" then
+    GoggleMaps.Options:Toggle()
   else
     GoggleMaps_Toggle()
   end


### PR DESCRIPTION
## Summary
Closes #16.

- Adds a new `components/Options.lua` component: a small standalone options window built with the existing `GoggleMaps.UI.Window` helper (same pattern as the debug window)
- One setting for now: a checkbox to minimize the map instead of closing it when Escape is pressed (default off, preserving current behavior)
- Escape currently closes the map via Blizzard's `UISpecialFrames`/`HideUIPanel` mechanism rather than a hookable local function, so the setting is implemented by patching the real global `HideUIPanel` (via `_G.HideUIPanel`, since this file runs in the addon's sandboxed environment) and only special-casing our own frame
- When the setting is on: first Escape press shrinks the map to mini mode (reusing the same `RestoreSizeAndPosition` helper the mini/maxi toggle uses) and keeps it open; since the frame is then already mini, a second Escape press falls through to the real close behavior — so Escape never gets "stuck"
- Opened via a new gear button on the main window's titlebar, or `/gmaps options`
- `/gmaps reset` now also resets the options DB

## Test plan
- [ ] Open the map, click the gear button and `/gmaps options` — panel opens/closes, checkbox state persists across `/reloadui`
- [ ] Checkbox off (default): Escape closes the map as before
- [ ] Checkbox on: Escape once shrinks to mini mode and stays open; Escape again closes it
- [ ] `/gmaps reset` doesn't error and the checkbox reverts to unchecked